### PR TITLE
Fixed json deserialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed json deserialization error
+
 ## [0.2.6] - 2020-10-28
 
 ## [0.2.5] - 2020-09-25

--- a/dotnet/Models/VtexOrder.cs
+++ b/dotnet/Models/VtexOrder.cs
@@ -254,7 +254,7 @@ namespace StorePickup.Models
         public string UserAgent { get; set; }
 
         [JsonProperty("userId")]
-        public Guid UserId { get; set; }
+        public string UserId { get; set; }
     }
 
     public class ItemMetadata


### PR DESCRIPTION
Fix for
Newtonsoft.Json.JsonSerializationException: Error converting value "" to type 'System.Guid'. Path 'contextData.userId', line 1, position 2354.